### PR TITLE
global: add pre_filters for repeated sources

### DIFF
--- a/inspire_json_merger/inspire_json_merger.py
+++ b/inspire_json_merger/inspire_json_merger.py
@@ -32,7 +32,7 @@ from inspire_json_merger.merger_config import (
     PublisherOnArxivOperations,
     PublisherOnPublisherOperations,
 )
-from inspire_json_merger.utils.filterout_utils import filter_out
+from inspire_json_merger.utils.filterout_utils import filter_conflicts, filter_records
 
 
 def inspire_json_merge(root, head, update, head_source=None):
@@ -57,6 +57,8 @@ def inspire_json_merge(root, head, update, head_source=None):
         get_acquisition_source(update)
     )
     conflicts = []
+
+    root, head, update = filter_records(root, head, update, filters=configuration.pre_filters)
     merger = Merger(
         root=root, head=head, update=update,
         default_dict_merge_op=configuration.default_dict_merge_op,
@@ -71,7 +73,7 @@ def inspire_json_merge(root, head, update, head_source=None):
     except MergeError as e:
         conflicts = e.content
 
-    conflicts = filter_out(conflicts, configuration.filter_out)
+    conflicts = filter_conflicts(conflicts, configuration.conflict_filters)
     conflicts = [json.loads(c.to_json()) for c in conflicts]
 
     merged = merger.merged_root

--- a/inspire_json_merger/merger_config.py
+++ b/inspire_json_merger/merger_config.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import, division, print_function
 from json_merger.config import DictMergerOps, UnifierOps
 
 from .comparators import COMPARATORS
+from .utils.filterout_utils import PRE_FILTERS
 """
 This module provides different sets of rules that `inspire_json_merge`
 """
@@ -33,17 +34,19 @@ This module provides different sets of rules that `inspire_json_merge`
 class MergerConfigurationOperations(object):
     default_dict_merge_op = DictMergerOps.FALLBACK_KEEP_UPDATE
     default_list_merge_op = UnifierOps.KEEP_ONLY_UPDATE_ENTITIES
-    filter_out = None
+    conflict_filters = None
+    comparators = None
+    pre_filters = None
     list_dict_ops = None
     list_merge_ops = None
-    comparators = None
 
 
 class ArxivOnArxivOperations(MergerConfigurationOperations):
     # We an always default to KEEP_UPDATE_AND_HEAD_ENTITIES_HEAD_FIRST so
     # this is less verbose.
     comparators = COMPARATORS
-    filter_out = [
+    pre_filters = PRE_FILTERS
+    conflict_filters = [
         '_collections',
         '_files',
         'abstracts',
@@ -239,7 +242,8 @@ class ArxivOnArxivOperations(MergerConfigurationOperations):
 
 class PublisherOnArxivOperations(MergerConfigurationOperations):
     comparators = COMPARATORS
-    filter_out = [
+    pre_filters = PRE_FILTERS
+    conflict_filters = [
         '_collections',
         '_files',
         'abstracts',
@@ -444,7 +448,8 @@ class PublisherOnPublisherOperations(MergerConfigurationOperations):
     # We an always default to KEEP_UPDATE_AND_HEAD_ENTITIES_HEAD_FIRST so
     # this is less verbose.
     comparators = COMPARATORS
-    filter_out = [
+    pre_filters = PRE_FILTERS
+    conflict_filters = [
         '_collections',
         '_files',
         'abstracts',

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ install_requires = [
     'inspire-schemas~=53.0,>=53.0.0',
     'inspire-utils~=0.0,>=0.0.13',
     'json-merger[contrib]~=0.0,>=0.3.2',
+    'pyrsistent~=0.0,>=0.14.0',
 ]
 
 docs_require = []

--- a/tests/unit/test_merger_arxiv2arxiv.py
+++ b/tests/unit/test_merger_arxiv2arxiv.py
@@ -3060,23 +3060,7 @@ def test_documents():
         ]
     }
 
-    expected_merged = {
-        'documents': [
-            {
-                'key': 'pdf.pdf',
-                'description': 'paper',
-                'source': 'arXiv',
-                'fulltext': True,
-                'url': '/files/5678-5678-5678-5678/pdf.pdf',
-            },
-            {
-                'key': 'foo.xml',
-                'description': 'some xml files',
-                'source': 'arXiv',
-                'url': '/files/5678-5678-5678-5678/foo.xml',
-            }
-        ]
-    }
+    expected_merged = update
     expected_conflict = []
 
     merged, conflict = inspire_json_merge(root, head, update,


### PR DESCRIPTION
This adds pre_filters to the merger rules that can preprocess the
records before handing them over to the merger, and implements a
pre-filter to remove the documents and figures from the head and root
matching the source in the update.

It also renames `filter_out` to `filter_conflicts` or
`conflict_filters` (for the function and attributes respectively) and
sipmlifies `is_to_delete`.

Signed-off-by: Micha Moskovic <michamos@gmail.com>