### PR TITLE
utils: fix issue with ``remove_elements_with_source``

### DIFF
--- a/inspire_json_merger/utils.py
+++ b/inspire_json_merger/utils.py
@@ -146,7 +146,8 @@ def conflict_to_list(conflict):
 
 def remove_elements_with_source(source, field):
     """Remove all elements matching ``source`` in ``field``."""
-    return [element for element in field if element.get('source') != source]
+    return freeze(
+        [element for element in field if element.get('source') != source])
 
 
 def keep_only_update_source_in_field(field, root, head, update):

--- a/tests/unit/test_filterout_utils.py
+++ b/tests/unit/test_filterout_utils.py
@@ -219,3 +219,45 @@ def test_filter_documents_same_source_multiple_sources_in_update():
     expected = root, head, update
 
     assert result == expected
+
+
+def test_filter_documents_remove_head_source():
+    root = {}
+    head = {
+        'documents': [
+            {
+                'source': 'publisher',
+                'key': 'file3.pdf',
+                'url': '/files/1234-1234-1234-1234/file3.pdf',
+            },
+            {
+                'source': 'arXiv',
+                'key': 'old_file.pdf',
+                'url': '/files/5678-5678-5678-5678/old_file.pdf',
+            },
+        ],
+    }
+    update = {
+        'documents': [
+            {
+                'source': 'publisher',
+                'key': 'file3.pdf',
+                'url': '/files/1234-1234-1234-1234/file3.pdf',
+            },
+
+        ],
+    }
+    expected_head = {
+        'documents': [
+            {
+                'source': 'arXiv',
+                'key': 'old_file.pdf',
+                'url': '/files/5678-5678-5678-5678/old_file.pdf',
+            },
+        ],
+    }
+
+    result = filter_documents_same_source(root, head, update)
+    expected = root, expected_head, update
+
+    assert result == expected


### PR DESCRIPTION
* Fixes issue with ``document`` and ``figures`` which
  ``remove_elements_with_source``  was returning ``pmap`` instead of dict
  after ``thaw``.

Signed-off-by: Harris Tzovanakis <me@drjova.com>