### PR TITLE
Improve comparators

### DIFF
--- a/inspire_json_merger/comparators.py
+++ b/inspire_json_merger/comparators.py
@@ -98,6 +98,7 @@ RecordComparator = get_pk_comparator(['record.$ref'])
 RefComparator = get_pk_comparator(['$ref'])
 SchemaComparator = get_pk_comparator(['schema'])
 SourceComparator = get_pk_comparator(['source'])
+SourceValueComparator = get_pk_comparator([['source', 'value']])
 TitleComparator = get_pk_comparator(['title'])
 URLComparator = get_pk_comparator(['url'])
 ValueComparator = get_pk_comparator(['value'])
@@ -142,7 +143,7 @@ COMPARATORS = {
     'copyright': MaterialComparator,
     'deleted_records': RefComparator,
     'documents': DocumentComparator,
-    'dois': ValueComparator,
+    'dois': SourceValueComparator,
     'external_system_identifiers': SchemaComparator,
     'figures': FigureComparator,
     'funding_info': FundingInfoComparator,
@@ -158,5 +159,5 @@ COMPARATORS = {
     'references.reference.authors': AuthorComparator,
     'report_numbers': ValueComparator,
     'title_translations': LanguageComparator,
-    'titles': TitleComparator
+    'titles': SourceComparator
 }

--- a/inspire_json_merger/comparators.py
+++ b/inspire_json_merger/comparators.py
@@ -85,6 +85,27 @@ def get_pk_comparator(primary_key_fields, normalization_functions=None):
     return Ret
 
 
+class NoMatch(object):
+    """Ensure the result of a normalization function is not a match."""
+    def __equals__(self, other):
+        return False
+
+
+class SubdictNormalizer(object):
+    """Normalizer that only looks at the keys passed as argument.
+
+    If any required key is not present, the element won't match.
+    """
+    def __init__(self, keys):
+        self.keys = set(keys)
+
+    def __call__(self, field):
+        if not self.keys.issubset(field.keys()):
+            return NoMatch()
+
+        return {k: field[k] for k in self.keys}
+
+
 AffiliationComparator = get_pk_comparator([['record.$ref'], ['value']])
 CollectionsComparator = get_pk_comparator(['primary'])
 CreationDatetimeComparator = get_pk_comparator(['creation_datetime'])
@@ -104,15 +125,19 @@ URLComparator = get_pk_comparator(['url'])
 ValueComparator = get_pk_comparator(['value'])
 
 
-ReferenceComparator = get_pk_comparator([
-    ['record'],
-    ['reference.arxiv_eprint'],
-    ['reference.dois'],
-    ['reference.isbn'],
-    ['reference.report_numbers'],
-    ['reference.persistent_identifiers'],
-    ['reference.publication_info']
-])
+ReferenceComparator = get_pk_comparator(
+    [
+        ['record'],
+        ['raw_refs'],
+        ['reference.arxiv_eprint'],
+        ['reference.dois'],
+        ['reference.isbn'],
+        ['reference.report_numbers'],
+        ['reference.persistent_identifiers'],
+        ['reference.publication_info']
+    ],
+    {'reference.publication_info': SubdictNormalizer(['journal_title', 'journal_volume', 'page_start'])}
+)
 
 PublicationInfoComparator = get_pk_comparator([
     ['journal_title', 'journal_volume']

--- a/inspire_json_merger/config.py
+++ b/inspire_json_merger/config.py
@@ -389,6 +389,7 @@ class PublisherOnArxivOperations(MergerConfigurationOperations):
         'authors.book_series',
         'authors.citeable',
         'authors.collaborations',
+        'curated',
         'control_number',
         'copyright',
         'core',

--- a/tests/unit/test_comparators.py
+++ b/tests/unit/test_comparators.py
@@ -115,6 +115,137 @@ def test_comparing_references_field_same_dois():
     validate_subschema(merged)
 
 
+def test_comparing_references_field_publication_info_match():
+    root = {}
+    head = {
+        'references': [
+            {
+                'reference': {
+                    'misc': [
+                        'Reference in head',
+                    ],
+                    'publication_info': {
+                        'journal_title': 'J.Testing',
+                        'journal_volume': '42',
+                        'page_start': '5',
+                        'year': 2009,
+                    },
+                },
+            },
+        ],
+    }
+    update = {
+        'references': [
+            {
+                'reference': {
+                    'misc': [
+                        'Reference in update',
+                    ],
+                    'publication_info': {
+                        'journal_title': 'J.Testing',
+                        'journal_volume': '42',
+                        'page_start': '5',
+                        'year': 2009,
+                    },
+                },
+            },
+        ],
+    }
+
+    expected_conflict = []
+    expected_merged = {
+        'references': [
+            {
+                'reference': {
+                    'misc': [
+                        'Reference in update',
+                    ],
+                    'publication_info': {
+                        'journal_title': 'J.Testing',
+                        'journal_volume': '42',
+                        'page_start': '5',
+                        'year': 2009,
+                    },
+                },
+            },
+        ],
+    }
+
+    root, head, update, expected_merged = add_arxiv_source(root, head, update, expected_merged)
+    merged, conflict = merge(root, head, update, head_source='arxiv')
+
+    merged = add_arxiv_source(merged)
+    assert merged == expected_merged
+    assert_ordered_conflicts(conflict, expected_conflict)
+    validate_subschema(merged)
+
+
+def test_comparing_references_field_publication_info_no_match():
+    root = {}
+    head = {
+        'references': [
+            {
+                'reference': {
+                    'misc': [
+                        'Reference in head',
+                    ],
+                    'publication_info': {
+                        'year': 2009,
+                    },
+                },
+            },
+        ],
+    }
+    update = {
+        'references': [
+            {
+                'reference': {
+                    'misc': [
+                        'Reference in update',
+                    ],
+                    'publication_info': {
+                        'year': 2009,
+                    },
+                },
+            },
+        ],
+    }
+
+    expected_conflict = []
+    expected_merged = {
+        'references': [
+            {
+                'reference': {
+                    'misc': [
+                        'Reference in head',
+                    ],
+                    'publication_info': {
+                        'year': 2009,
+                    },
+                }
+            },
+            {
+                'reference': {
+                    'misc': [
+                        'Reference in update',
+                    ],
+                    'publication_info': {
+                        'year': 2009,
+                    },
+                },
+            },
+        ],
+    }
+
+    root, head, update, expected_merged = add_arxiv_source(root, head, update, expected_merged)
+    merged, conflict = merge(root, head, update, head_source='arxiv')
+
+    merged = add_arxiv_source(merged)
+    assert merged == expected_merged
+    assert_ordered_conflicts(conflict, expected_conflict)
+    validate_subschema(merged)
+
+
 def test_comparing_references_field_different_dois():
     root = {}
     head = {

--- a/tests/unit/test_merger_arxiv2arxiv.py
+++ b/tests/unit/test_merger_arxiv2arxiv.py
@@ -1274,7 +1274,11 @@ def test_merging_dois_field():
                 'material': 'preprint',
                 'source': 'nowhere',
                 'value': '10.1023/A:1026654312961'
-            }
+            },
+            {
+                'source': 'nowhere',
+                'value': '10.1023/B:1026654312961'
+            },
         ]
     }
     update = {
@@ -1282,17 +1286,31 @@ def test_merging_dois_field():
             {
                 'material': 'publication',
                 'value': '10.1023/A:1026654312961'
-            }
+            },
+            {
+                'material': 'erratum',
+                'source': 'nowhere',
+                'value': '10.1023/B:1026654312961'
+            },
         ]
     }
 
     expected_merged = {
         'dois': [
             {
-                'material': 'publication',
+                'material': 'preprint',
                 'source': 'nowhere',
                 'value': '10.1023/A:1026654312961'
-            }
+            },
+            {
+                'material': 'publication',
+                'value': '10.1023/A:1026654312961'
+            },
+            {
+                'material': 'erratum',
+                'source': 'nowhere',
+                'value': '10.1023/B:1026654312961'
+            },
         ]
     }
     expected_conflict = []
@@ -2077,7 +2095,7 @@ def test_merging_titles_field():
     ]}
     update = {'titles': [
         {
-            'source': 'submitter',
+            'source': 'arXiv',
             'title': 'ANTARES: Un osservatorio foo bar'
         }, {
             'source': 'submitter',
@@ -2087,7 +2105,7 @@ def test_merging_titles_field():
 
     expected_merged = {'titles': [
         {
-            'source': 'submitter',
+            'source': 'arXiv',
             'title': 'ANTARES: Un osservatorio foo bar'
         }, {
             'source': 'submitter',


### PR DESCRIPTION
This makes several changes to comparators:
* it uses `source` for comparing `titles` and `source` and `value` for `dois`
* it improves comparison of `references` by requiring some fields in the `publication_info` to be present before a match is declared. Note that this will result in more duplicate elements in the reference list after the merge due to references that contain too little information to be matched.