### PR TITLE
comparators: remove raw_affilitations comparator

### DIFF
--- a/inspire_json_merger/comparators.py
+++ b/inspire_json_merger/comparators.py
@@ -127,7 +127,6 @@ COMPARATORS = {
     'authors': AuthorComparator,
     'authors.affiliations': AffiliationComparator,
     'authors.ids': SchemaComparator,
-    'authors.raw_affiliations': SourceComparator,
     'book_series': TitleComparator,
     'collaborations': RecordComparator,
     'copyright': MaterialComparator,

--- a/tests/unit/test_merger_arxiv2arxiv.py
+++ b/tests/unit/test_merger_arxiv2arxiv.py
@@ -859,6 +859,10 @@ def test_merging_raw_affiliations_field():
                     {
                         'source': 'arxiv',
                         'value': 'Department of Physics, Indiana University, Bloomington, IN 47405, US'
+                    },
+                    {
+                        'source': 'arxiv',
+                        'value': 'Padua U',
                     }
                 ]
             }


### PR DESCRIPTION
The previous `SourceComparator` caused problems when there are multiple
raw_affiliations from the same source, as sometimes happens with arXiv.

Signed-off-by: Micha Moskovic <michamos@gmail.com>