### PR TITLE
pre-filters: ignore authors for ref comparison

### DIFF
--- a/inspire_json_merger/pre_filters.py
+++ b/inspire_json_merger/pre_filters.py
@@ -135,6 +135,7 @@ def _normalize_ref(ref):
     ref = _remove_if_falsy(ref, 'curated_relation')
     ref = _remove_if_present(ref, 'raw_refs')
     ref = ref.transform(['reference'], lambda reference: _remove_if_present(reference, 'misc'))
+    ref = ref.transform(['reference'], lambda reference: _remove_if_present(reference, 'authors'))
     return ref
 
 

--- a/tests/unit/test_pre_filters.py
+++ b/tests/unit/test_pre_filters.py
@@ -290,6 +290,7 @@ def test_filter_curated_references_keeps_update_if_head_almost_equal_to_root():
                 'reference': {
                     'arxiv_eprint': '1810.12345',
                     'misc': ['foo'],
+                    'authors': ['Smith, J.'],
                 },
                 'raw_refs': [
                     {
@@ -328,7 +329,7 @@ def test_filter_curated_references_keeps_update_if_head_almost_equal_to_root():
     assert result == expected
 
 
-def test_filter_curated_references_keeps_update_if_head_almost_equal_to_root_with_curated():
+def test_filter_curated_references_keeps_head_if_head_almost_equal_to_root_with_curated():
     root = {
         'references': [
             {


### PR DESCRIPTION
Authors cause issues in the round-trip to legacy

INSPIR-2955