### PR TITLE
Workaround for arXiv `preprint_date` update bug

### DIFF
--- a/inspire_json_merger/config.py
+++ b/inspire_json_merger/config.py
@@ -34,6 +34,7 @@ from inspire_json_merger.pre_filters import (
     filter_publisher_references,
     remove_references_from_update,
     remove_root,
+    remove_root_preprint_date,
     update_authors_with_ordering_info,
     update_material,
 )
@@ -60,6 +61,7 @@ class ArxivOnArxivOperations(MergerConfigurationOperations):
         filter_figures_same_source,
         filter_curated_references,
         update_authors_with_ordering_info,
+        remove_root_preprint_date,
     ]
     conflict_filters = [
         '_collections',
@@ -128,6 +130,7 @@ class ArxivOnPublisherOperations(MergerConfigurationOperations):
         filter_publisher_references,
         update_authors_with_ordering_info,
         clean_root_for_acquisition_source,
+        remove_root_preprint_date,
     ]
     default_list_merge_op = U.KEEP_ONLY_HEAD_ENTITIES
     conflict_filters = [

--- a/inspire_json_merger/pre_filters.py
+++ b/inspire_json_merger/pre_filters.py
@@ -239,3 +239,9 @@ def update_material(root, head, update):
 
 def remove_root(root, head, update):
     return pmap({}), head, update
+
+
+def remove_root_preprint_date(root, head, update):
+    "Workaround for arXiv bug in new OAI-PMH API"
+    root = _remove_if_present(root, "preprint_date")
+    return root, head, update

--- a/tests/unit/test_merger.py
+++ b/tests/unit/test_merger.py
@@ -1238,3 +1238,26 @@ def test_merging_copyright(fake_get_config):
     merged, conflict = merge(root, head, update)
     assert "copyright" not in merged
     assert "persistent_identifiers" not in merged
+
+
+def test_preprint_date_doesnt_update():
+    root = {
+        "acquisition_source": {"method": "hepcrawl", "source": "arxiv"},
+        "preprint_date": "2022-12-12",
+    }
+    head = {
+        "acquisition_source": {"method": "hepcrawl", "source": "arxiv"},
+        "preprint_date": "2022-12-12",
+    }
+    update = {
+        "acquisition_source": {"method": "hepcrawl", "source": "arxiv"},
+        "preprint_date": "2025-06-20",
+    }
+
+    expected_merged = head
+    expected_conflict = []
+
+    merged, conflict = merge(root, head, update, head_source='arxiv')
+    assert merged == expected_merged
+    assert_ordered_conflicts(conflict, expected_conflict)
+    validate_subschema(merged)


### PR DESCRIPTION
This ensures that `preprint_date` never gets updated by removing it from the root if present there in order to force a 2-way merge.